### PR TITLE
Swift nio

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,17 +15,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "902b18df16897da644724bd4b85b4bbe952ac9c6",
-          "version": "1.5.1"
+          "revision": "a5db2a67515ad2b490ac5646db204a5edf939f47",
+          "version": "1.6.1"
         }
       },
       {
         "package": "swift-nio-ssl",
-        "repositoryURL": "https://github.com/Yasumoto/swift-nio-ssl.git",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "fdf89b5e46ef0839edb58cbbeafc3ee2486e7685",
-          "version": "1.0.2"
+          "revision": "38955a5f806a952daf2b16fbfe9aa529749cf1dd",
+          "version": "1.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,6 @@ import PackageDescription
 let package = Package(
     name: "AWSSDKSwiftCore",
     products: [
-        .executable(name: "tester", targets: ["AWSSDKSwiftCore"]),
         .library(name: "AWSSDKSwiftCore", targets: ["AWSSDKSwiftCore"])
     ],
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.5.1"),
-        .package(url: "https://github.com/Yasumoto/swift-nio-ssl.git", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.1.0"),
         .package(url: "https://github.com/Yasumoto/HypertextApplicationLanguage.git", .upToNextMajor(from: "1.1.0"))
     ],
     targets: [

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -132,8 +132,9 @@ extension AWSClient {
             throw RequestError.invalidURL("\(url)")
         }
         let client = HTTPClient(hostname: hostname, port: port)
-        let future = try client.connect()
+        let future = try client.connect(body: request.body)
         let response = try future.wait()
+
         client.close { error in
             if let error = error {
                 print("Error closing connection: \(error)")

--- a/Sources/AWSSDKSwiftCore/HTTPClient.swift
+++ b/Sources/AWSSDKSwiftCore/HTTPClient.swift
@@ -164,6 +164,7 @@ public final class HTTPClient {
         let response: EventLoopPromise<Response> = eventGroup.next().newPromise()
 
         _ = ClientBootstrap(group: eventGroup)
+            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .channelInitializer { channel in
                 let accumulation = HTTPClientResponseHandler(promise: response)
                 let results = preHandlers.map { channel.pipeline.add(handler: $0) }

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -66,7 +66,17 @@ struct MetaDataService {
     }
 
     private static func request(url: URL, timeout: TimeInterval) throws -> Response {
-        let client = HTTPClient(hostname: url.absoluteString, port: 80)
+        guard let scheme = url.scheme else {
+            throw MetaDataServiceError.couldNotGetInstanceRoleName
+        }
+        var port: Int {
+            let isSecure = scheme == "https" || scheme == "wss"
+            return isSecure ? 443 : Int(url.port ?? 80)
+        }
+        guard let hostname = url.host else {
+            throw MetaDataServiceError.couldNotGetInstanceRoleName
+        }
+        let client = HTTPClient(hostname: hostname, port: port)
         return try client.connect().wait()
     }
 


### PR DESCRIPTION
 in AWSClient#invoke you were initializing the HTTPClient with `request.head.uri` and no port

and in MetaDataService#request you initialized with HTTPClient `url.absoluteString` and hardcode the port to 80.

neither of these will work correctly. The hostname passed to the `ClientBootstrap` `connect` method is passed on to a `GetaddrinfoResolver` which performs a dns lookup on the hostname. So it has to be the host, without the protocol or path.

And of course the port could be 443 for tls requests, so it has to be set in the call to connect(host:, :port)

Let me know what you think of the solution in this pr

Next we'll need to ensure we write the body to the channel handler. I started by passing it to the connect method from the AWSClient#invoke. 

Also there are some failing tests that need attn (SerializersTests, TimeStampTests...) 

Then maybe we can talk about calling .wait() on the future and if there is any practical way around this that won't require a much larger rewrite of this sdk...

final note  - sorry for all the whitespace removal, I don't use xcode.